### PR TITLE
requirements.txt: get rid of paramiko deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ oauth2client
 PyOpenSSL
 wakeonlan
 credentials
+cryptography==2.5


### PR DESCRIPTION
Signed-off-by: Artur Raglis <artur.raglis@3mdeb.com>